### PR TITLE
[WRD-9] ADD: 버튼 컴포넌트 구현

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,0 @@
-const Button = () => {
-  return <div>Button</div>;
-};
-
-export default Button;

--- a/src/components/ButtonComponent.tsx
+++ b/src/components/ButtonComponent.tsx
@@ -1,0 +1,27 @@
+import { CSSProperties, DetailedHTMLProps } from 'react';
+import styled from 'styled-components';
+
+type Props = DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> & {
+  title?: string;
+  width?: string | number;
+  height?: string | number;
+  background?: string | number;
+  color?: string | number;
+};
+
+const ButtonComponent = (props: Props) => {
+  return <Button {...props}>{props.title}</Button>;
+};
+export default ButtonComponent;
+
+const Button = styled.button<CSSProperties>`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  background: ${({ background }) => background};
+  color: ${({ color }) => color};
+  border: none;
+  border-radius: 8px;
+`;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,7 +1,19 @@
+import ButtonComponent from '../../components/ButtonComponent';
 import * as S from './Login.style';
 
 const Login = () => {
-  return <S.Container>Login</S.Container>;
+  return (
+    <>
+      <S.Container>
+        <ButtonComponent
+          title="재활용 버튼"
+          width={'300px'}
+          height={'60px'}
+          background={'#FFDC89'}
+        ></ButtonComponent>
+      </S.Container>
+    </>
+  );
 };
 
 export default Login;


### PR DESCRIPTION
## 트렐로 티켓

- WRD-9

## 구현 사항

- 재사용 가능한 버튼 컴포넌트 구현
- 버튼의 이름(title), width, height, backbround를 받는 버튼 컴포넌트를 구현하였습니다.

## 구현 사항 상세

- 인포트한 버튼 컴포넌트의 사용 예시 : 

<img width="300" alt="스크린샷 2023-07-18 오후 8 10 33" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/b024177c-158f-4688-b491-6a6b4fe237dd">
<img width="253" alt="스크린샷 2023-07-18 오후 8 10 18" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/c2f47afa-6a77-4429-8c54-5aa1437abcf8">



## 구현 화면

-
