### PR TITLE
[WRD-9] ADD: 버튼 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@types/styled-components": "^5.1.26",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-icons": "^4.10.1",
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1",
         "styled-components": "^6.0.4",
@@ -14635,14 +14634,6 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
-    },
-    "node_modules/react-icons": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
-      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
-      "peerDependencies": {
-        "react": "*"
-      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@types/styled-components": "^5.1.26",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.10.1",
     "react-router-dom": "^6.14.1",
     "react-scripts": "5.0.1",
     "styled-components": "^6.0.4",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,0 @@
-const Button = () => {
-  return <div>Button</div>;
-};
-
-export default Button;

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -1,0 +1,22 @@
+import ButtonProps from './Button.type';
+import styled from 'styled-components';
+
+const ButtonComponent = styled.button<ButtonProps>`
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  background: ${({ background, theme }) =>
+    background ?? theme[background as unknown as keyof typeof theme]};
+
+  border: none;
+  border-radius: 8px;
+
+  color: ${({ color }) => color};
+  text-align: center;
+  font-family: 'Noto Sans KR', sans-serif;
+  font-size: ${({ fontSize }) => fontSize};
+  font-weight: ${({ fontWeight }) => fontWeight};
+
+  cursor: pointer;
+`;
+
+export default ButtonComponent;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,8 @@
+import ButtonProps from './Button.type';
+import ButtonComponent from './Button.style';
+
+const Button = (props: ButtonProps) => {
+  return <ButtonComponent {...props}>{props.title}</ButtonComponent>;
+};
+
+export default Button;

--- a/src/components/Button/Button.type.tsx
+++ b/src/components/Button/Button.type.tsx
@@ -1,0 +1,16 @@
+import { DetailedHTMLProps } from 'react';
+
+type ButtonProps = DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> & {
+  title?: string;
+  width?: string;
+  height?: string;
+  background?: string;
+  color?: string | number;
+  fontSize: string;
+  fontWeight: number;
+};
+
+export default ButtonProps;

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,15 +1,5 @@
-import { RiAccountPinBoxLine } from 'react-icons/ri';
-import { FiMoreHorizontal } from 'react-icons/fi';
-import { GoPeople } from 'react-icons/go';
-import { BsClock } from 'react-icons/bs';
-import { BiMap } from 'react-icons/bi';
+const Icons = () => {
+  return <div>Icons</div>;
+};
 
-export const ProfileIcon = () => <RiAccountPinBoxLine />;
-
-export const MoreDetail = () => <FiMoreHorizontal />;
-
-export const PeopleLimit = () => <GoPeople />;
-
-export const TimeLimitIcon = () => <BsClock />;
-
-export const Location = () => <BiMap />;
+export default Icons;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,7 +1,11 @@
 import * as S from './Login.style';
 
 const Login = () => {
-  return <S.Container>Login</S.Container>;
+  return (
+    <>
+      <S.Container></S.Container>
+    </>
+  );
 };
 
 export default Login;


### PR DESCRIPTION
## 트렐로 티켓

- WRD-9

## 구현 사항

- (23.07.18) 재사용 가능한 버튼 컴포넌트 구현 : 버튼의 이름(title), width, height, backbround를 받는 버튼 컴포넌트를 구현하였습니다.
- (23.07.19) theme 컬러도 사용 가능하게 스타일 컴포넌트 수정
- (23.07.19) font, cursor 스타일 추가

## 구현 사항 상세

- 인포트한 버튼 컴포넌트의 사용 예시 :
<img width="440" alt="스크린샷 2023-07-19 오후 7 17 16" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/aacfb881-f7e8-429f-a9da-c6e8c28fe8d9">



## 구현 화면

<img width="256" alt="스크린샷 2023-07-19 오후 7 16 54" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/884af144-fbac-4bb7-ac6d-76592ab619bd">

