### PR TITLE
[WRD-8] ADD: 인풋 컴포넌트 구현

### DIFF
--- a/public/icons/checkTrue.svg
+++ b/public/icons/checkTrue.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8" fill="none">
+<circle cx="4" cy="4" r="4" fill="#FFDC89"/>
+</svg>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,5 +1,4 @@
 const Icons = () => {
   return <div>Icons</div>;
 };
-
 export default Icons;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,5 +1,0 @@
-const Input = () => {
-  return <div>Input</div>;
-};
-
-export default Input;

--- a/src/components/Input/Input.style.ts
+++ b/src/components/Input/Input.style.ts
@@ -1,0 +1,47 @@
+import { CSSProperties } from 'react';
+import { styled } from 'styled-components';
+
+export const InputTitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+
+  & span {
+    margin-right: 6px;
+    color: #f9483b;
+    text-align: center;
+  }
+`;
+
+export const InputTeg = styled.input<CSSProperties>`
+  width: 320px;
+  height: ${({ height }) => height ?? '30px'};
+  padding: 9px 10px;
+
+  border: 1px solid #ffdc89;
+  border-radius: 8px;
+
+  background: #ffffff;
+  color: ${({ color }) => color};
+
+  &::placeholder {
+    color: #9e9e9e;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+  }
+`;
+
+export const CheckboxInput = styled.input`
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border: 1px solid #808080;
+  border-radius: 50%;
+
+  &:checked {
+    background-image: url('/icons/checkTrue.svg');
+    background-repeat: no-repeat;
+    background-position: 50%;
+  }
+`;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,21 @@
+import InputProps from './Input.type';
+import * as S from './Input.style';
+
+const Input = (props: InputProps) => {
+  return (
+    <label>
+      {props.title !== '' && (
+        <S.InputTitleWrapper>
+          {props.required === true && <span>*</span>} {props.title}
+        </S.InputTitleWrapper>
+      )}
+      {props.type === 'checkbox' ? (
+        <S.CheckboxInput {...props} />
+      ) : (
+        <S.InputTeg {...props} />
+      )}
+    </label>
+  );
+};
+
+export default Input;

--- a/src/components/Input/Input.type.tsx
+++ b/src/components/Input/Input.type.tsx
@@ -1,0 +1,11 @@
+type InputProps = React.DetailedHTMLProps<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+> & {
+  type: string;
+  title?: string;
+  placeholder?: string;
+  required?: boolean;
+};
+
+export default InputProps;


### PR DESCRIPTION
## 트렐로 티켓

- WRD-8

## 구현 사항

- 인풋 컴포넌트 구현
- type 별로 조건식에 따른 스타일 부여

## 구현 사항 상세 및 구현 화면

<img width="306" alt="스크린샷 2023-07-18 오후 11 57 37" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/a675395a-2b73-42ed-a921-3551e1747dd5">
<img width="74" alt="스크린샷 2023-07-18 오후 11 57 59" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/3a61fc14-342a-455a-ac4c-8ee71fd7f762">
<img width="74" alt="스크린샷 2023-07-18 오후 11 57 49" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/4f65d1b3-52f8-4a40-ac87-f93785b64ac7">

<br />
<img width="306" alt="스크린샷 2023-07-18 오후 11 57 23" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/0e54f44c-dc22-46f5-b78f-d7ae03831329">
<img width="306" alt="스크린샷 2023-07-18 오후 11 56 40" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/a4334a09-eccb-4a30-ac85-8148b783560c">



## 궁금한 사항 (해결완료)

- 스타일컴포넌트에서 props에 대한 조건식을 작성할 때 || 기호 사용에 대한 에러가 발생했는데, ??로 변경하라고 에러 알림이 뜹니다. ??라고 변경은 해두었으나 서칭을 해도 원인을 모르겠습니다.
- 해결 : ?? 연산자는 null 또는 undefined인 경우에만 우변의 값을 반환하므로, 더 안전한 방식으로 사용할 수 있습니다.

<img width="756" alt="스크린샷 2023-07-18 오후 11 47 43" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/0783b665-18b7-4cec-968f-e18a81c11d42">
<img width="756" alt="스크린샷 2023-07-18 오후 11 47 49" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/90b4b55b-32f0-41a3-a988-857c8fea9175">
