### PR TITLE
[Fix] 인풋 컴포넌트 수정

### DIFF
--- a/public/icons/checkTrue.svg
+++ b/public/icons/checkTrue.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8" fill="none">
+<circle cx="4" cy="4" r="4" fill="#FFDC89"/>
+</svg>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,0 +1,4 @@
+const Icons = () => {
+  return <div>Icons</div>;
+};
+export default Icons;

--- a/src/components/Input/Input.style.ts
+++ b/src/components/Input/Input.style.ts
@@ -1,15 +1,17 @@
 import { CSSProperties } from 'react';
 import { styled } from 'styled-components';
+import { mixins } from '../../styles/mixins';
+import { typo } from '../../styles/typo';
+import theme from '../../styles/theme';
 
 export const InputTitleWrapper = styled.div`
-  display: flex;
-  align-items: center;
   margin-bottom: 8px;
-  color: #000;
-  font-size: 14px;
   font-style: normal;
-  font-weight: 400;
   line-height: normal;
+
+  ${mixins.flexBox('', 'center')}
+  ${theme.colors.mainBlack}
+  ${typo.normal}
 
   & span {
     margin-right: 6px;
@@ -26,20 +28,27 @@ export const InputTeg = styled.input<CSSProperties>`
   border: 1px solid #ffdc89;
   border-radius: 8px;
 
-  background: #ffffff;
+  background: ${theme.colors.white};
   color: ${({ color }) => color};
 
   &::placeholder {
-    color: #9e9e9e;
-    font-family: 'Noto Sans KR', sans-serif;
-    font-size: 12px;
     font-style: normal;
-    font-weight: 400;
     line-height: normal;
+    color: ${theme.colors.disable};
+
+    ${typo.small}
   }
 `;
 
-export const CheckboxInput = styled.input`
+export const CheckContainer = styled.div`
+  display: flex;
+`;
+
+export const GenderContainer = styled.div`
+  ${mixins.flexBox('', 'center')}
+`;
+
+export const GenderCheckbox = styled.input`
   appearance: none;
   width: 14px;
   height: 14px;
@@ -51,4 +60,9 @@ export const CheckboxInput = styled.input`
     background-repeat: no-repeat;
     background-position: 50%;
   }
+`;
+
+export const GenderLabel = styled.label`
+  width: 60px;
+  ${typo.small}
 `;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -3,19 +3,31 @@ import * as S from './Input.style';
 
 const Input = (props: InputProps) => {
   return (
-    <label>
+    <div>
       {props.title !== '' && (
         <S.InputTitleWrapper>
           {props.required === true && <span>*</span>} {props.title}
         </S.InputTitleWrapper>
       )}
-      {props.type === 'checkbox' ? (
-        <S.CheckboxInput {...props} />
-      ) : (
-        <S.InputTeg {...props} />
-      )}
-    </label>
+      <S.CheckContainer>
+        {props.type === 'checkbox' ? (
+          GENDER_INFO.map(({ id, gender, value }) => (
+            <S.GenderContainer key={id}>
+              <S.GenderCheckbox {...props} value={value} />
+              <S.GenderLabel>{gender}</S.GenderLabel>
+            </S.GenderContainer>
+          ))
+        ) : (
+          <S.InputTeg {...props} />
+        )}
+      </S.CheckContainer>
+    </div>
   );
 };
 
 export default Input;
+
+const GENDER_INFO = [
+  { id: 1, gender: '남성', value: 'male' },
+  { id: 2, gender: '여성', value: 'female' },
+];


### PR DESCRIPTION
## 트렐로 티켓

- Fix/InputComponent

## 구현 사항

- input의 checkbox 분기처리 리턴 코드 수정
- input 스타일 수정

## 구현 사항 상세

- checkbox일 경우 성별 체크박스 2개가 보이게 수정

## 구현 화면

<img width="489" alt="스크린샷 2023-07-21 오후 10 05 03" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/bddc769e-f2ad-4680-a3cd-8cbaff416db5">

<img width="199" alt="스크린샷 2023-07-21 오후 10 04 12" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/ecf3bcdc-aca2-4d5b-b72e-dd1c089f6b10">

<img width="199" alt="스크린샷 2023-07-21 오후 10 04 21" src="https://github.com/Woori-Dongne/frontend-react/assets/121158293/c9f89683-650b-428e-8890-1934abccbc54">
