### PR TITLE
[WRD -4] ADD : 글 작성 페이지 레이아웃 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^18.2.7",
         "@types/react-router-dom": "^5.3.3",
         "@types/styled-components": "^5.1.26",
+        "aws-sdk": "^2.1426.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1",
@@ -5231,6 +5232,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-sdk": {
+      "version": "2.1426.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1426.0.tgz",
+      "integrity": "sha512-qq4ydcRzQW2IqjMdCz5FklORREEtkSCJ2tm9CUJ2PaUOaljxpdxq9UI64vXiyRD+GIp5vdkmVNoTRi2rCXh3rA==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
@@ -5524,6 +5566,25 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5699,10 +5760,25 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/buffer/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -9252,6 +9328,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -9508,6 +9589,20 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -11823,6 +11918,14 @@
       "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/js-tokens": {
@@ -14393,6 +14496,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -16722,6 +16834,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -16729,6 +16850,23 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -17666,6 +17804,26 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^18.2.7",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.26",
+    "aws-sdk": "^2.1426.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,6 @@
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap"
       rel="stylesheet"
     />
-
     <title>React App</title>
   </head>
   <body>

--- a/src/assets/arrowdown.svg
+++ b/src/assets/arrowdown.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="vuesax/linear/arrow-down">
+<g id="vuesax/linear/arrow-down_2">
+<g id="arrow-down">
+<path id="Vector" d="M19.9201 8.94995L13.4001 15.47C12.6301 16.24 11.3701 16.24 10.6001 15.47L4.08008 8.94995" stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+</g>
+</svg>

--- a/src/assets/arrowup.svg
+++ b/src/assets/arrowup.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="vuesax/linear/arrow-up">
+<g id="vuesax/linear/arrow-up_2">
+<g id="arrow-up">
+<path id="Vector" d="M19.9201 15.05L13.4001 8.53001C12.6301 7.76001 11.3701 7.76001 10.6001 8.53001L4.08008 15.05" stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+</g>
+</svg>

--- a/src/assets/upload.svg
+++ b/src/assets/upload.svg
@@ -1,0 +1,13 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="vuesax/linear/gallery-add">
+<g id="vuesax/linear/gallery-add_2">
+<g id="gallery-add">
+<path id="Vector" d="M9 10C10.1046 10 11 9.10457 11 8C11 6.89543 10.1046 6 9 6C7.89543 6 7 6.89543 7 8C7 9.10457 7.89543 10 9 10Z" stroke="#292D32" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M13 2H9C4 2 2 4 2 9V15C2 20 4 22 9 22H15C20 22 22 20 22 15V10" stroke="#292D32" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M15.75 5H21.25" stroke="#292D32" stroke-width="1.5" stroke-linecap="round"/>
+<path id="Vector_4" d="M18.5 7.75V2.25" stroke="#292D32" stroke-width="1.5" stroke-linecap="round"/>
+<path id="Vector_5" d="M2.66992 18.9501L7.59992 15.6401C8.38992 15.1101 9.52992 15.1701 10.2399 15.7801L10.5699 16.0701C11.3499 16.7401 12.6099 16.7401 13.3899 16.0701L17.5499 12.5001C18.3299 11.8301 19.5899 11.8301 20.3699 12.5001L21.9999 13.9001" stroke="#292D32" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+</g>
+</svg>

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -7,7 +7,6 @@ const ButtonComponent = styled.button<ButtonProps>`
   text-align: center;
   font-style: normal;
   line-height: normal;
-
   cursor: pointer;
 
   ${(props) => BORDER[props.$border]}

--- a/src/components/ConstantData/constantDatalist.ts
+++ b/src/components/ConstantData/constantDatalist.ts
@@ -1,0 +1,136 @@
+interface Item {
+  id: number;
+  title: string | number;
+}
+
+interface ConstList {
+  [key: string]: Item[];
+  CATEGORY_SORT: Item[];
+  PERSONNEL_LIMIT: Item[];
+  DEADLINE_YEAR: Item[];
+  DEADLINE_MONTH: Item[];
+  DEADLINE_DAY: Item[];
+}
+
+const CATEGORY_SORT: Item[] = [
+  { id: 1, title: '배달' },
+  { id: 2, title: '공구' },
+  { id: 3, title: '산책' },
+  { id: 4, title: '운동' },
+];
+
+const DEADLINE_YEAR: Item[] = [
+  { id: 1, title: 2023 },
+  { id: 2, title: 2024 },
+  { id: 3, title: 2025 },
+  { id: 4, title: 2026 },
+];
+
+const DEADLINE_MONTH: Item[] = [
+  { id: 1, title: 1 },
+  { id: 2, title: 2 },
+  { id: 3, title: 3 },
+  { id: 4, title: 4 },
+  { id: 5, title: 5 },
+  { id: 6, title: 6 },
+  { id: 7, title: 7 },
+  { id: 8, title: 8 },
+  { id: 9, title: 9 },
+  { id: 10, title: 10 },
+  { id: 11, title: 11 },
+  { id: 12, title: 12 },
+];
+
+const DEADLINE_DAY: Item[] = [
+  { id: 1, title: 1 },
+  { id: 2, title: 2 },
+  { id: 3, title: 3 },
+  { id: 4, title: 4 },
+  { id: 5, title: 5 },
+  { id: 6, title: 6 },
+  { id: 7, title: 7 },
+  { id: 8, title: 8 },
+  { id: 9, title: 9 },
+  { id: 10, title: 10 },
+  { id: 11, title: 11 },
+  { id: 12, title: 12 },
+  { id: 13, title: 13 },
+  { id: 14, title: 14 },
+  { id: 15, title: 15 },
+  { id: 16, title: 16 },
+  { id: 17, title: 17 },
+  { id: 18, title: 18 },
+  { id: 19, title: 19 },
+  { id: 20, title: 20 },
+  { id: 21, title: 21 },
+  { id: 22, title: 22 },
+  { id: 23, title: 23 },
+  { id: 24, title: 24 },
+  { id: 25, title: 25 },
+  { id: 26, title: 26 },
+  { id: 27, title: 27 },
+  { id: 28, title: 28 },
+  { id: 29, title: 29 },
+  { id: 30, title: 30 },
+  { id: 31, title: 31 },
+];
+
+const PERSONNEL_LIMIT: Item[] = [
+  { id: 1, title: '1~2' },
+  { id: 2, title: '2~3' },
+  { id: 3, title: '3~4' },
+  { id: 4, title: '4~5' },
+  { id: 5, title: '5~6' },
+];
+
+const DEADLINE_HOUR: Item[] = [
+  { id: 1, title: 1 },
+  { id: 2, title: 2 },
+  { id: 3, title: 3 },
+  { id: 4, title: 4 },
+  { id: 5, title: 5 },
+  { id: 6, title: 6 },
+  { id: 7, title: 7 },
+  { id: 8, title: 8 },
+  { id: 9, title: 9 },
+  { id: 10, title: 10 },
+  { id: 11, title: 11 },
+  { id: 12, title: 12 },
+  { id: 13, title: 13 },
+  { id: 14, title: 14 },
+  { id: 15, title: 15 },
+  { id: 16, title: 16 },
+  { id: 17, title: 17 },
+  { id: 18, title: 18 },
+  { id: 19, title: 19 },
+  { id: 20, title: 20 },
+  { id: 21, title: 21 },
+  { id: 22, title: 22 },
+  { id: 23, title: 23 },
+  { id: 24, title: 24 },
+];
+
+const DEADLINE_MINUTE: Item[] = [
+  { id: 1, title: 0 },
+  { id: 2, title: 5 },
+  { id: 3, title: 10 },
+  { id: 4, title: 15 },
+  { id: 5, title: 20 },
+  { id: 6, title: 25 },
+  { id: 7, title: 30 },
+  { id: 8, title: 35 },
+  { id: 9, title: 40 },
+  { id: 10, title: 45 },
+  { id: 11, title: 50 },
+  { id: 12, title: 55 },
+];
+
+export const constantList: ConstList = {
+  CATEGORY_SORT,
+  DEADLINE_YEAR,
+  DEADLINE_MONTH,
+  DEADLINE_DAY,
+  PERSONNEL_LIMIT,
+  DEADLINE_HOUR,
+  DEADLINE_MINUTE,
+};

--- a/src/components/DropDown/DropDownModal.style.ts
+++ b/src/components/DropDown/DropDownModal.style.ts
@@ -1,0 +1,43 @@
+import { CSSProperties } from 'react';
+import { styled } from 'styled-components';
+import { mixins } from '../../styles/mixins';
+import { typo } from '../../styles/typo';
+
+export const CategoryDropDownContainer = styled.div`
+  position: relative;
+`;
+
+export const CategoryDropDown = styled.div<CSSProperties>`
+  ${mixins.flexBox('space-between', 'center')}
+  ${typo.small}
+  width: ${({ width }) => width};
+  height: 30px;
+  border: 1px solid ${({ theme }) => theme.colors.mainYellow};
+  border-radius: 8px;
+  margin-top: 15px;
+  padding: 0 10px;
+  z-index: 70;
+`;
+export const DropBox = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 200px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  box-shadow: 4px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  z-index: 10;
+  overflow-y: scroll;
+  background-color: white;
+`;
+
+export const DropBoxDetail = styled.div`
+  ${mixins.flexBox()}
+  margin-top:3px;
+  padding: 15px 27px 15px 26px;
+  text-align: center;
+  ${typo.h3}
+  &:hover {
+    cursor: pointer;
+    background-color: rgba(217, 217, 217, 0.3);
+  }
+`;

--- a/src/components/DropDown/DropDownModal.tsx
+++ b/src/components/DropDown/DropDownModal.tsx
@@ -1,0 +1,61 @@
+import { constantList } from '../ConstantData/constantDatalist';
+import Icon from '../Icon';
+import * as S from './DropDownModal.style';
+
+interface Props {
+  title: string | any;
+  id: number;
+}
+
+interface DropDownModalProps {
+  name: string;
+  width?: string;
+  handleOpenModal?: () => void;
+  stateValue: string;
+  isOpen: boolean;
+  // setSelectSort: (category: string) => void
+  setSelectSort: any;
+}
+
+const DropDownModal = ({
+  name,
+  width,
+  handleOpenModal,
+  stateValue,
+  isOpen,
+  setSelectSort,
+}: DropDownModalProps) => {
+  return (
+    <S.CategoryDropDownContainer>
+      <S.CategoryDropDown onClick={handleOpenModal} width={width}>
+        {stateValue}
+        {isOpen ? (
+          <Icon name="arrowdown" width="20px" height="24px" />
+        ) : (
+          <Icon name="arrowup" width="20px" height="24px" />
+        )}
+      </S.CategoryDropDown>
+      {isOpen && (
+        <S.DropBox>
+          {constantList[name].map(({ title, id }: Props) => {
+            return (
+              <S.DropBoxDetail
+                key={id}
+                onClick={() => {
+                  setSelectSort(title);
+                  if (handleOpenModal != null) {
+                    handleOpenModal();
+                  }
+                }}
+              >
+                {title}
+              </S.DropBoxDetail>
+            );
+          })}
+        </S.DropBox>
+      )}
+    </S.CategoryDropDownContainer>
+  );
+};
+
+export default DropDownModal;

--- a/src/components/DropDown/index.ts
+++ b/src/components/DropDown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DropDownModal';

--- a/src/components/Icon/iconList.ts
+++ b/src/components/Icon/iconList.ts
@@ -10,6 +10,9 @@ import notFound from '../../assets/notFound.svg';
 import out from '../../assets/out.svg';
 import more from '../../assets/more.svg';
 import logos from '../../assets/logos.svg';
+import arrowup from '../../assets/arrowup.svg';
+import arrowdown from '../../assets/arrowdown.svg';
+import upload from '../../assets/upload.svg';
 
 interface IconList {
   [key: string]: string;
@@ -25,6 +28,9 @@ interface IconList {
   out: string;
   more: string;
   logos: string;
+  arrowup: string;
+  arrowdown: string;
+  upload: string;
 }
 
 export const iconList: IconList = {
@@ -40,4 +46,7 @@ export const iconList: IconList = {
   out,
   more,
   logos,
+  arrowup,
+  arrowdown,
+  upload,
 };

--- a/src/components/Input/Input.style.ts
+++ b/src/components/Input/Input.style.ts
@@ -6,11 +6,9 @@ import theme from '../../styles/theme';
 
 export const InputTitleWrapper = styled.div`
   ${mixins.flexBox('', 'center')}
-
+  ${typo.normal}
   margin-bottom: 8px;
   text-align: center;
-
-  ${typo.normal}
 
   & span {
     height: 14px;
@@ -21,7 +19,7 @@ export const InputTitleWrapper = styled.div`
 `;
 
 export const InputTeg = styled.input<CSSProperties>`
-  width: 320px;
+  width: 100%;
   height: ${({ height }) => height ?? '30px'};
   padding: 0px 10px;
 
@@ -30,7 +28,6 @@ export const InputTeg = styled.input<CSSProperties>`
 
   background: ${theme.colors.white};
   color: ${({ color }) => color};
-
   &::placeholder {
     font-style: normal;
     line-height: normal;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -3,7 +3,7 @@ import * as S from './Input.style';
 
 const Input = (props: InputProps) => {
   return (
-    <div>
+    <>
       {props.title !== '' && (
         <S.InputTitleWrapper>
           {props.required === true && <span>*</span>} {props.title}
@@ -21,7 +21,7 @@ const Input = (props: InputProps) => {
           <S.InputTeg {...props} />
         )}
       </S.CheckContainer>
-    </div>
+    </>
   );
 };
 

--- a/src/components/Modal/Modal.style.ts
+++ b/src/components/Modal/Modal.style.ts
@@ -24,6 +24,7 @@ export const ModalContainer = styled.div`
 `;
 
 export const ConfrimContent = styled.div`
+  ${({ theme }) => theme.colors.black}
   ${typo.normal};
   width: 200px;
   text-align: center;

--- a/src/hooks/useSelectHook.tsx
+++ b/src/hooks/useSelectHook.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+
+const useSelectHook = () => {
+  const [inputText, setInputText] = useState({
+    titleText: '',
+    detailText: '',
+    pickupPlaceText: '',
+  });
+
+  const [selectValue, setSelectValue] = useState({
+    selectCategory: '카테고리를 선택해 주세요.',
+    selectPersonnel: '인원을 선택해 주세요',
+    selectYearDeadline: '연도',
+    selectMonthDeadline: '월',
+    selectDayDeadline: '일',
+    selectHourDeadline: '시간',
+    selectMinuteDeadline: '분',
+  });
+
+  const [isOpenModal, setIsOpenModal] = useState({
+    isOpenYearModal: false,
+    isOpenMonthModal: false,
+    isOpenDayModal: false,
+    isOpenHourModal: false,
+    isOpenMinuteModal: false,
+    showPostModal: false,
+  });
+
+  const onChangeHandler = (
+    e:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const { value, name } = e.target;
+    setInputText({ ...inputText, [name]: value });
+  };
+
+  const openYearModal = () => {
+    setIsOpenModal({
+      ...isOpenModal,
+      isOpenYearModal: !isOpenModal.isOpenYearModal,
+    });
+  };
+
+  const openMonthModal = () => {
+    setIsOpenModal({
+      ...isOpenModal,
+      isOpenMonthModal: !isOpenModal.isOpenMonthModal,
+    });
+  };
+  const openDayModal = () => {
+    setIsOpenModal({
+      ...isOpenModal,
+      isOpenDayModal: !isOpenModal.isOpenDayModal,
+    });
+  };
+
+  const openHourModal = () => {
+    setIsOpenModal({
+      ...isOpenModal,
+      isOpenHourModal: !isOpenModal.isOpenHourModal,
+    });
+  };
+
+  const openMinuteModal = () => {
+    setIsOpenModal({
+      ...isOpenModal,
+      isOpenMinuteModal: !isOpenModal.isOpenMinuteModal,
+    });
+  };
+
+  return {
+    inputText,
+    selectValue,
+    isOpenModal,
+    onChangeHandler,
+    setSelectValue,
+    setIsOpenModal,
+    openYearModal,
+    openMonthModal,
+    openDayModal,
+    openHourModal,
+    openMinuteModal,
+  };
+};
+
+export default useSelectHook;

--- a/src/pages/Writing/Writing.style.ts
+++ b/src/pages/Writing/Writing.style.ts
@@ -1,3 +1,74 @@
 import { styled } from 'styled-components';
+import { mixins } from '../../styles/mixins';
+import { typo } from '../../styles/typo';
+export const Container = styled.div`
+  padding: 31px 20px;
+`;
 
-export const Container = styled.div``;
+export const Remind = styled.h3`
+  ${typo.small}
+  span {
+    color: ${({ theme }) => theme.colors.mainRed};
+  }
+`;
+
+export const DeadlineBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+`;
+
+export const DeadlineName = styled.h3`
+  font-size: 14px;
+
+  span {
+    margin-right: 4px;
+    color: #f9483b;
+  }
+`;
+
+export const Deadline = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const DateDeadline = styled.div`
+  ${mixins.flexBox('space-between', 'center')}
+  height: 30px;
+  margin-top: 15px;
+`;
+
+export const TimeDeadline = styled.div`
+  ${mixins.flexBox('space-between', 'center')}
+  margin-top:15px;
+  font-size: 12px;
+  font-weight: 400;
+`;
+
+export const HourDeadline = styled.div`
+  ${mixins.flexBox('', 'center')}
+  width: 149px;
+  height: 16px;
+  border: 1px solid ${({ theme }) => theme.colors.mainYellow};
+  border-radius: 8px;
+  padding: 5px 6.02px 5px 7.52px;
+  color: #292d32;
+  font-size: 12px;
+  font-weight: 400;
+`;
+
+export const MinuteDeadline = styled.div`
+  ${mixins.flexBox('', 'center')}
+  width: 149px;
+  height: 16px;
+  border: 1px solid #ffdc89;
+  border-radius: 8px;
+  padding: 5px 6.02px 5px 7.52px;
+  color: #292d32;
+  font-size: 12px;
+  font-weight: 400;
+`;
+
+export const ButtonBox = styled.div`
+  margin-top: 60px;
+`;

--- a/src/pages/Writing/Writing.tsx
+++ b/src/pages/Writing/Writing.tsx
@@ -1,7 +1,211 @@
+import { useNavigate } from 'react-router-dom';
+import Category from './components/Category';
+import Detail from './components/Detail/Detail';
+import Title from './components/Title/Title';
+import Pickup from './components/Pickup/Pickup';
+import Upload from './components/Upload/Upload';
+import Personnel from './components/Personnel/Personnel';
+import DropDownModal from '../../components/DropDown/DropDownModal';
+import Button from '../../components/Button/Button';
+import Modal from '../../components/Modal';
+import useSelectHook from '../../hooks/useSelectHook';
 import * as S from './Writing.style';
 
 const Writing = () => {
-  return <S.Container>Writing</S.Container>;
+  const {
+    inputText,
+    selectValue,
+    isOpenModal,
+    onChangeHandler,
+    setSelectValue,
+    setIsOpenModal,
+    openYearModal,
+    openMonthModal,
+    openDayModal,
+    openHourModal,
+    openMinuteModal,
+  } = useSelectHook();
+
+  const { titleText, detailText, pickupPlaceText } = inputText;
+
+  const {
+    selectCategory,
+    selectPersonnel,
+    selectYearDeadline,
+    selectMonthDeadline,
+    selectDayDeadline,
+    selectHourDeadline,
+    selectMinuteDeadline,
+  } = selectValue;
+
+  const {
+    isOpenYearModal,
+    isOpenMonthModal,
+    isOpenDayModal,
+    isOpenHourModal,
+    isOpenMinuteModal,
+    showPostModal,
+  } = isOpenModal;
+
+  const lockScroll = () => {
+    document.body.style.overflow = 'hidden';
+  };
+
+  const unlockScroll = () => {
+    document.body.style.removeProperty('overflow');
+  };
+
+  const clickPostButton = () => {
+    setIsOpenModal({ ...isOpenModal, showPostModal: true });
+    lockScroll();
+  };
+
+  const navigate = useNavigate();
+
+  const sucessToPost = () => {
+    navigate('/main');
+    unlockScroll();
+  };
+
+  const activeButton =
+    titleText.length > 1 &&
+    selectCategory !== '카테고리를 선택해 주세요.' &&
+    selectPersonnel !== '인원을 선택해 주세요' &&
+    pickupPlaceText.length > 1 &&
+    selectYearDeadline !== '연도' &&
+    selectMonthDeadline !== '월' &&
+    selectDayDeadline !== '일' &&
+    selectHourDeadline !== '시간' &&
+    selectMinuteDeadline !== '분';
+
+  return (
+    <S.Container>
+      <S.Remind>
+        앞에 (<span>✴︎</span>)표시가 있는 항목은 필수 항목입니다.
+      </S.Remind>
+      <Title titleText={titleText} handleChangeTitle={onChangeHandler} />
+      <Category
+        selectCategory={selectCategory}
+        setSelectCategory={(value: any) => {
+          setSelectValue({ ...selectValue, selectCategory: value });
+        }}
+      />
+      <Detail detailText={detailText} handleChangeDetail={onChangeHandler} />
+      <Upload />
+      <Pickup
+        pickupPlaceText={pickupPlaceText}
+        handleChangePickupPlace={onChangeHandler}
+      />
+      <Personnel
+        selectPersonnel={selectPersonnel}
+        setSelectPersonnel={(value: any) => {
+          setSelectValue({ ...selectValue, selectPersonnel: value });
+        }}
+      />
+      <S.DeadlineBox>
+        <S.DeadlineName>
+          <span>✴︎</span> 마감 기한
+        </S.DeadlineName>
+        <S.Deadline>
+          <S.DateDeadline>
+            <DropDownModal
+              width="97px"
+              handleOpenModal={openYearModal}
+              isOpen={isOpenYearModal}
+              stateValue={selectYearDeadline}
+              setSelectSort={(value: any) => {
+                setSelectValue({
+                  ...selectValue,
+                  selectYearDeadline: value,
+                });
+              }}
+              name="DEADLINE_YEAR"
+            />
+            <DropDownModal
+              width="97px"
+              handleOpenModal={openMonthModal}
+              isOpen={isOpenMonthModal}
+              stateValue={selectMonthDeadline}
+              setSelectSort={(value: any) => {
+                setSelectValue({
+                  ...selectValue,
+                  selectMonthDeadline: value,
+                });
+              }}
+              name="DEADLINE_MONTH"
+            />
+            <DropDownModal
+              width="97px"
+              handleOpenModal={openDayModal}
+              isOpen={isOpenDayModal}
+              stateValue={selectDayDeadline}
+              setSelectSort={(value: any) => {
+                setSelectValue({
+                  ...selectValue,
+                  selectDayDeadline: value,
+                });
+              }}
+              name="DEADLINE_DAY"
+            />
+          </S.DateDeadline>
+          <S.TimeDeadline>
+            <DropDownModal
+              width="149px"
+              handleOpenModal={openHourModal}
+              isOpen={isOpenHourModal}
+              stateValue={selectHourDeadline}
+              setSelectSort={(value: any) => {
+                setSelectValue({
+                  ...selectValue,
+                  selectHourDeadline: value,
+                });
+              }}
+              name="DEADLINE_HOUR"
+            />
+            <DropDownModal
+              width="149px"
+              handleOpenModal={openMinuteModal}
+              isOpen={isOpenMinuteModal}
+              stateValue={selectMinuteDeadline}
+              setSelectSort={(value: any) => {
+                setSelectValue({
+                  ...selectValue,
+                  selectMinuteDeadline: value,
+                });
+              }}
+              name="DEADLINE_MINUTE"
+            />
+          </S.TimeDeadline>
+        </S.Deadline>
+      </S.DeadlineBox>
+      <S.ButtonBox>
+        <Button
+          title="글 작성하기"
+          $buttonbackground={activeButton ? 'mainYellow' : 'disable'}
+          $border="none"
+          $buttonsize="large"
+          $font={activeButton ? 'black' : 'white'}
+          onClick={clickPostButton}
+          disabled={!activeButton}
+        />
+        {showPostModal && (
+          <Modal
+            type="confirm"
+            confirmMessage={
+              <>
+                해당 내용으로 <br /> 글을 등록할까요?
+              </>
+            }
+            confirmAction={sucessToPost}
+            cancelAction={() => {
+              setIsOpenModal({ ...isOpenModal, showPostModal: false });
+              unlockScroll();
+            }}
+          />
+        )}
+      </S.ButtonBox>
+    </S.Container>
+  );
 };
 
 export default Writing;

--- a/src/pages/Writing/components/Category/Category.style.ts
+++ b/src/pages/Writing/components/Category/Category.style.ts
@@ -1,0 +1,14 @@
+import { styled } from 'styled-components';
+import { typo } from '../../../../styles/typo';
+
+export const CategoryBox = styled.div`
+  margin-top: 20px;
+`;
+
+export const CategoryName = styled.h3`
+  ${typo.normal}
+  span {
+    margin-right: 4px;
+    color: ${({ theme }) => theme.colors.mainRed};
+  }
+`;

--- a/src/pages/Writing/components/Category/Category.tsx
+++ b/src/pages/Writing/components/Category/Category.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import DropDownModal from '../../../../components/DropDown/DropDownModal';
+import * as S from './Category.style';
+
+interface CategoryProps {
+  selectCategory: string;
+  setSelectCategory: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const Category = ({ selectCategory, setSelectCategory }: CategoryProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const openDropBox = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <S.CategoryBox>
+      <S.CategoryName>
+        <span>✴︎</span> 카테고리
+      </S.CategoryName>
+      <DropDownModal
+        name="CATEGORY_SORT"
+        handleOpenModal={openDropBox}
+        isOpen={isOpen}
+        stateValue={selectCategory}
+        setSelectSort={setSelectCategory}
+      />
+    </S.CategoryBox>
+  );
+};
+
+export default Category;

--- a/src/pages/Writing/components/Category/index.tsx
+++ b/src/pages/Writing/components/Category/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Category';

--- a/src/pages/Writing/components/Detail/Detail.style.ts
+++ b/src/pages/Writing/components/Detail/Detail.style.ts
@@ -1,0 +1,29 @@
+import { styled } from 'styled-components';
+import { typo } from '../../../../styles/typo';
+
+export const DetailBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+`;
+
+export const DetailName = styled.h3`
+  width: 74px;
+  height: 20px;
+  ${typo.normal}
+`;
+
+export const DetailContent = styled.textarea`
+  height: 128px;
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.mainYellow};
+  margin-top: 9px;
+  resize: none;
+  padding: 5px 9px 5px 10px;
+  ::placeholder {
+    &::placeholder {
+      color: #9e9e9e;
+      ${typo.small}
+    }
+  }
+`;

--- a/src/pages/Writing/components/Detail/Detail.tsx
+++ b/src/pages/Writing/components/Detail/Detail.tsx
@@ -1,0 +1,23 @@
+import * as S from './Detail.style';
+
+interface DetailProps {
+  detailText: string;
+  handleChangeDetail: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+const Detail = ({ detailText, handleChangeDetail }: DetailProps) => {
+  return (
+    <S.DetailBox>
+      <S.DetailName>상세 내용</S.DetailName>
+      <S.DetailContent
+        placeholder="최대 300글자까지 입력 가능합니다"
+        maxLength={300}
+        value={detailText}
+        onChange={handleChangeDetail}
+        name="detailText"
+      />
+    </S.DetailBox>
+  );
+};
+
+export default Detail;

--- a/src/pages/Writing/components/Detail/index.tsx
+++ b/src/pages/Writing/components/Detail/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Detail';

--- a/src/pages/Writing/components/Personnel/Personnel.style.ts
+++ b/src/pages/Writing/components/Personnel/Personnel.style.ts
@@ -1,0 +1,13 @@
+import { styled } from 'styled-components';
+
+export const PersonnelBox = styled.div`
+  margin-top: 20px;
+`;
+
+export const PersonnelName = styled.h3`
+  font-size: 14px;
+  span {
+    margin-right: 4px;
+    color: #f9483b;
+  }
+`;

--- a/src/pages/Writing/components/Personnel/Personnel.tsx
+++ b/src/pages/Writing/components/Personnel/Personnel.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import DropDownModal from '../../../../components/DropDown/DropDownModal';
+import * as S from './Personnel.style';
+
+interface PersonnelProps {
+  selectPersonnel: string;
+  setSelectPersonnel: any;
+}
+
+const Personnel = ({ selectPersonnel, setSelectPersonnel }: PersonnelProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const openDropBox = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return (
+    <S.PersonnelBox>
+      <S.PersonnelName>
+        <span>✴︎</span> 인원
+      </S.PersonnelName>
+
+      <DropDownModal
+        handleOpenModal={openDropBox}
+        stateValue={selectPersonnel}
+        isOpen={isOpen}
+        setSelectSort={setSelectPersonnel}
+        name="PERSONNEL_LIMIT"
+      />
+    </S.PersonnelBox>
+  );
+};
+
+export default Personnel;

--- a/src/pages/Writing/components/Personnel/index.tsx
+++ b/src/pages/Writing/components/Personnel/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Personnel';

--- a/src/pages/Writing/components/Pickup/Pickup.style.ts
+++ b/src/pages/Writing/components/Pickup/Pickup.style.ts
@@ -1,0 +1,7 @@
+import { styled } from 'styled-components';
+
+export const PickUpPlaceBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+`;

--- a/src/pages/Writing/components/Pickup/Pickup.tsx
+++ b/src/pages/Writing/components/Pickup/Pickup.tsx
@@ -1,0 +1,25 @@
+import Input from '../../../../components/Input/Input';
+import * as S from './Pickup.style';
+
+interface PickupProps {
+  pickupPlaceText: string;
+  handleChangePickupPlace: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const Pickup = ({ pickupPlaceText, handleChangePickupPlace }: PickupProps) => {
+  return (
+    <S.PickUpPlaceBox>
+      <Input
+        title="예상 픽업 장소"
+        required={true}
+        type=""
+        placeholder="동 주소와 상세 주소를 작성해주세요"
+        value={pickupPlaceText}
+        onChange={handleChangePickupPlace}
+        name="pickupPlaceText"
+      />
+    </S.PickUpPlaceBox>
+  );
+};
+
+export default Pickup;

--- a/src/pages/Writing/components/Pickup/index.tsx
+++ b/src/pages/Writing/components/Pickup/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Pickup';

--- a/src/pages/Writing/components/Title/Title.style.ts
+++ b/src/pages/Writing/components/Title/Title.style.ts
@@ -1,0 +1,5 @@
+import { styled } from 'styled-components';
+
+export const TitleBox = styled.div`
+  margin-top: 9px;
+`;

--- a/src/pages/Writing/components/Title/Title.tsx
+++ b/src/pages/Writing/components/Title/Title.tsx
@@ -1,0 +1,26 @@
+import Input from '../../../../components/Input/Input';
+import * as S from './Title.style';
+
+interface TitleProps {
+  titleText: string;
+  handleChangeTitle: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const Title = ({ titleText, handleChangeTitle }: TitleProps) => {
+  return (
+    <S.TitleBox>
+      <Input
+        title="제목"
+        required={true}
+        type=""
+        placeholder="최대 30글자까지 입력 가능합니다"
+        maxLength={30}
+        value={titleText}
+        onChange={handleChangeTitle}
+        name="titleText"
+      />
+    </S.TitleBox>
+  );
+};
+
+export default Title;

--- a/src/pages/Writing/components/Title/index.tsx
+++ b/src/pages/Writing/components/Title/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Title';

--- a/src/pages/Writing/components/Upload/Upload.style.ts
+++ b/src/pages/Writing/components/Upload/Upload.style.ts
@@ -1,0 +1,26 @@
+import { styled } from 'styled-components';
+import { mixins } from '../../../../styles/mixins';
+import { typo } from '../../../../styles/typo';
+
+export const ImageUploadContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+`;
+
+export const ImageUpLoadName = styled.h3`
+  ${typo.normal}
+`;
+
+export const ImageUpLoadBox = styled.label`
+  ${mixins.flexBox()}
+  margin-top: 9px;
+  height: 128px;
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.mainYellow};
+`;
+
+export const ImageUpLoad = styled.img`
+  width: 100%;
+  height: 126px;
+`;

--- a/src/pages/Writing/components/Upload/Upload.tsx
+++ b/src/pages/Writing/components/Upload/Upload.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import Icon from '../../../../components/Icon';
+import * as S from './Upload.style';
+
+const Upload = () => {
+  const [imgSrc, setImgSrc] = useState<string | null>(null);
+
+  const chgPreview = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files != null) {
+      const imageFile = e.target.files[0];
+      if (imageFile != null) {
+        const imageUrl = URL.createObjectURL(imageFile);
+        setImgSrc(imageUrl);
+      }
+    }
+  };
+
+  return (
+    <S.ImageUploadContainer>
+      <S.ImageUpLoadName>이미지 업로드</S.ImageUpLoadName>
+      <S.ImageUpLoadBox>
+        {imgSrc === null ? (
+          <Icon name="upload" width="24px" height="24px" />
+        ) : (
+          <S.ImageUpLoad src={imgSrc} />
+        )}
+
+        <input
+          type="file"
+          onChange={chgPreview}
+          style={{ display: 'none' }}
+          id="imgSrc"
+        />
+      </S.ImageUpLoadBox>
+    </S.ImageUploadContainer>
+  );
+};
+
+export default Upload;

--- a/src/pages/Writing/components/Upload/index.tsx
+++ b/src/pages/Writing/components/Upload/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Upload';

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -10,6 +10,9 @@ export const GlobalStyle = createGlobalStyle`
 
   a{
     cursor:pointer;
+    background-color: rgba(217, 217, 217, 0.30);
+
+    
   }
 
   ul, ol, li {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -9,7 +9,7 @@ const colors = {
   white: '#FFFFFF',
 
   kakao: '#F9DF4A',
-  disable: '#9E9E9E',
+  disable: 'rgba(158, 158, 158, 0.50)',
   hover: '#D9D9D9',
   feedBack: '#FCFCFC',
 };


### PR DESCRIPTION
## 트렐로 티켓

- WRD-4

## 구현 사항

-  레이아웃 및 모달창 컨포넌트화, 버튼 비활성화 구현

## 구현 사항 상세

- 드랍다운 레이아웃때문에 div태그로 구현
- useState boolean과 string 두개를 만들어  div태그를 누르면 화살표 방향이 바뀌고 모달창에 해당하는 글을 누르면 div태그에 value값이 들어가게 구현
- 조건에 따른 버튼 색깔과 비활성화 

## 수정해야할 사항

- constantDatalist 부분 수정해야함(너무 하드코딩)
- 해당 티켓 머지되면 새로 브랜치 파서 이미지 업로드 구현할 예정
-  any 타입 수정해야함

## 구현 화면



https://github.com/Woori-Dongne/frontend-react/assets/122069802/e4aff863-0cb2-44e8-8c37-3ed0d062eae5





